### PR TITLE
docs: GitHubページへのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ![top](images/top.png)
 
-翻訳コミュニティ月例ミートアップ 用のイベント及び翻訳手順の説明サイトです。
+[翻訳コミュニティ月例ミートアップ 用のイベント及び翻訳手順の説明サイトです](https://mozilla-japan.github.io/mdn-translation-guide/)。


### PR DESCRIPTION
READMEの文言を GitHub Pages のリンクにしました。
