### PR TITLE
refs(#3): `main` に `push` もしくは `merge` した時に GitHub Pagesにデプロイするように設定

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Install dependencies
+        run: npm install
+      - name: Generate Documents
+        run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./_book
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
@gurezo 

Closes: #3 

## 概要

`main` ブランチに `push` もしくは `merge` した時に GitHub PagesにデプロイするようにGitHub Actionsを設定してみました。

## サンプル

個人リポジトリでブランチに直接 `push` したケースと、 PRを `merge` したケースで GitHubPagesにデプロイできることを確認しています。

- [試したリポジトリ](https://github.com/yoshinorin/honkit-ghaction-publish-sandbox)
- [デプロイ先のGitHub Pages](https://yoshinorin.github.io/honkit-ghaction-publish-sandbox/)
- [ブランチ(master)にpushした時のログ](https://github.com/yoshinorin/honkit-ghaction-publish-sandbox/actions/runs/3437428246)
- [PRマージした時のログ](https://github.com/yoshinorin/honkit-ghaction-publish-sandbox/actions/runs/3437520496)


## 事前作業

このPRをマージする前に、リポジトリの `Settings -> Pages -> Source` で `GitHub Actions (Beta)` を設定してください。

![gh-action-publish](https://user-images.githubusercontent.com/11273093/201116280-dab79ebc-4f63-4e8f-a494-1c3a922c8db4.jpg)

## P.S

マージ後に上手くデプロイされない等あればメンションいただければ調査お手伝いします 🙏 