### PR TITLE
update package honkit v4.x to v6.x

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 22.x
       - name: Install dependencies
         run: npm install
       - name: Generate Documents

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/mozilla-japan/mdn-translation-guide#readme",
   "devDependencies": {
-    "gh-pages": "^4.0.0",
-    "honkit": "^4.0.0"
+    "gh-pages": "^6.1.1",
+    "honkit": "^6.0.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
close #16 

[honkit v6.x](https://github.com/honkit/honkit/releases/tag/v6.0.0) がリリースされたので、アップデートしました。
最新バージョンに合わせて、node のバージョンも v14.x => v22.x に変更しました。

追記
ワークフローの node のバージョンも v22.x に変更しました。
